### PR TITLE
fix generated files path

### DIFF
--- a/anchor/codama.js
+++ b/anchor/codama.js
@@ -3,7 +3,7 @@
 import { createCodamaConfig } from './src/create-codama-config.js'
 
 export default createCodamaConfig({
-  clientJs: 'anchor/src/t3flip/client/js/generated',
+  clientJs: 'anchor/src/client/js/generated',
   idl: 'target/idl/t3_flip.json',
 })
 


### PR DESCRIPTION
run `npm run codama:js`. Files should generate in correct directory now:

<img width="344" height="257" alt="image" src="https://github.com/user-attachments/assets/b410ff87-eaf4-46ef-aa0b-22d9b8de2c8a" />
